### PR TITLE
Changed the date for an event to show only the date and not the time

### DIFF
--- a/Inventory Management System/frontend/src/pages/EventInventory.js
+++ b/Inventory Management System/frontend/src/pages/EventInventory.js
@@ -239,9 +239,10 @@ const EventInventory = () => {
                                 </>
                             ) : (
                                 <>
-                                    <span>{event?.name || 'No event name'}</span> - <span>{event?.date || 'No event date'}</span>
+                                    <span>{event?.name || 'No event name'}</span> - 
+                                    <span>{new Date(event?.date).toLocaleDateString('en-US', { timeZone: 'UTC' })}</span>
                                     <button onClick={() => handleEditEvent(event?._id, event)}>Edit Event</button>
-                                    <button onClick={() => handleDeleteEvent(event?._id)}>Delete Event</button> {/* New Delete button */}
+                                    <button onClick={() => handleDeleteEvent(event?._id)}>Delete Event</button>
                                 </>
                             )}
 


### PR DESCRIPTION
 I also saw I had an issue where editing a date of an event would cause the newly set day to show up the day before on the inventory but, show up correctly in the database. It all works now.